### PR TITLE
feature/#46_Add_the_concept_of_store_owner_permissions_and_optimize_Foodbook

### DIFF
--- a/src/app/controllers/application_controller.rb
+++ b/src/app/controllers/application_controller.rb
@@ -6,8 +6,26 @@ class ApplicationController < ActionController::Base
     return redirect_to login_url, danger: '権限がありません' unless logged_in?
 
     unless current_user.admin? || current_user?(@user)
-      @user = User.find(params[:id])
-      redirect_to user_url(current_user), danger: '権限がありません'
+      redirect_to user_url(current_user),
+                  danger: '権限がありません'
+    end
+  end
+
+  def correct_shop
+    return redirect_to login_url, danger: '権限がありません' unless logged_in?
+
+    unless current_user.admin? || current_users_shop?(@shop)
+      redirect_to user_url(current_user),
+                  danger: '権限がありません'
+    end
+  end
+
+  def correct_menu
+    return redirect_to login_url, danger: '権限がありません' unless logged_in?
+
+    unless current_user.admin? || current_users_shop_menu?(@menu)
+      redirect_to user_url(current_user),
+                  danger: '権限がありません'
     end
   end
 end

--- a/src/app/controllers/menus_controller.rb
+++ b/src/app/controllers/menus_controller.rb
@@ -1,6 +1,6 @@
 class MenusController < ApplicationController
   before_action :set_menu, only: %i[show edit update destroy]
-  before_action :correct_user, only: %i[new create edit update destroy]
+  before_action :correct_menu, only: %i[edit update destroy]
   def index
     @menus = Menu.page(params[:page]).per(10)
   end
@@ -14,13 +14,11 @@ class MenusController < ApplicationController
 
   def new
     @menu = Menu.new
+    @shops = current_user.shops
   end
 
   def create
-    # ログイン機能の実装までの仮
-    @shop = Shop.find(session[:user_id])
-    @menu = @shop.menus.new menu_params
-    # @menu = Menu.new(name: params[:name], price: params[:price], evaluation: 3, shop_id: 1)
+    @menu = Menu.new menu_params
     return redirect_to menu_url(@menu), success: "メニュー「#{@menu.name}」を作成しました" if @menu.save
 
     render :new
@@ -42,7 +40,7 @@ class MenusController < ApplicationController
   private
 
   def menu_params
-    params.require(:menu).permit(:name, :price, :evaluation)
+    params.require(:menu).permit(:name, :price, :evaluation, :shop_id)
   end
 
   def set_menu

--- a/src/app/controllers/shops_controller.rb
+++ b/src/app/controllers/shops_controller.rb
@@ -1,6 +1,6 @@
 class ShopsController < ApplicationController
   before_action :set_shop, only: %i[show edit update destroy]
-  before_action :correct_user, only: %i[new create edit update destroy]
+  before_action :correct_shop, only: %i[edit update destroy]
   def index
     @shops = Shop.page(params[:page]).per(10)
   end
@@ -8,6 +8,7 @@ class ShopsController < ApplicationController
   def show
     @menus = Menu.where(shop_id: params[:id]).page(params[:page]).per(5)
     @menus_count = @shop.menus.count
+    @user = @shop.user
   end
 
   def new
@@ -37,7 +38,7 @@ class ShopsController < ApplicationController
   private
 
   def shop_params
-    params.require(:shop).permit(:name, :business_hour, :address)
+    params.require(:shop).permit(:name, :business_hour, :address).merge(user_id: current_user.id)
   end
 
   def set_shop

--- a/src/app/controllers/users_controller.rb
+++ b/src/app/controllers/users_controller.rb
@@ -8,6 +8,7 @@ class UsersController < ApplicationController
 
   def show
     @likes = Like.where(user_id: params[:id])
+    @user_shops = Shop.where(user_id: @user.id)
   end
 
   def new

--- a/src/app/helpers/sessions_helper.rb
+++ b/src/app/helpers/sessions_helper.rb
@@ -16,6 +16,16 @@ module SessionsHelper
     user == current_user
   end
 
+  # カレントユーザーの店である？
+  def current_users_shop?(shop)
+    shop.user_id == current_user.id
+  end
+
+  # カレントユーザーの店である？
+  def current_users_shop_menu?(menu)
+    menu.shop.user_id == current_user.id
+  end
+
   # カレントユーザーが作ったもの？
   def current_user_item?(item)
     current_user.id == item.user.id if current_user

--- a/src/app/models/shop.rb
+++ b/src/app/models/shop.rb
@@ -1,5 +1,6 @@
 class Shop < ApplicationRecord
   has_many :menus, foreign_key: 'shop_id', dependent: :destroy
+  belongs_to :user
 
   validates :name, presence: true, uniqueness: true
   validates :business_hour, presence: true

--- a/src/app/models/user.rb
+++ b/src/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_many :comments, foreign_key: 'user_id', dependent: :destroy
   has_many :replies, foreign_key: 'user_id', dependent: :destroy
   has_many :likes, foreign_key: 'user_id', dependent: :destroy
+  has_many :shops, foreign_key: 'user_id', dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 20 }
   validates :email, presence: true, uniqueness: true

--- a/src/app/views/layouts/_header.html.slim
+++ b/src/app/views/layouts/_header.html.slim
@@ -18,8 +18,11 @@ div.nav-box
       li.nav-item = link_to  "ログアウト", logout_path, method: "delete" 
     - elsif logged_in?
       li.nav-item = link_to "メニュー一覧", menus_path
+      - if current_user.shops.present?
+        li.nav-item = link_to "メニューを登録する", new_menu_path
       / li.nav-item = link_to "お気に入りメニュー", root_path
       li.nav-item = link_to  "店舗一覧", shops_path 
+      li.nav-item = link_to "店舗を登録する", new_shop_path
       li.nav-item = link_to  "ログアウト", logout_path, method: "delete" 
     - else
       li.nav-item = link_to "メニュー一覧", menus_path

--- a/src/app/views/menus/new.html.slim
+++ b/src/app/views/menus/new.html.slim
@@ -3,6 +3,9 @@
 .form-box
   = form_with model: @menu, local: true do |f|
     .form-group 
+      = f.label :shop_id, "店舗"
+      = f.collection_select :shop_id, current_user.shops, :id, :name, class: "form-control"
+    .form-group 
       = f.label :name, 'メニュー名'
       = f.text_field :name, class: 'form-control'
     .form-group

--- a/src/app/views/menus/show.html.slim
+++ b/src/app/views/menus/show.html.slim
@@ -19,7 +19,7 @@ ul.menu_profile
         | #{@likes.count}
   - else 
     p = "❤︎ #{@likes.count}"
-- if admin?
+- if admin? || @menu.shop.user_id == current_user.id
   ul.btn-box
     li = link_to  "編集", edit_menu_path(@menu)
     li = link_to  "削除", menu_path, method: "delete", data: {confirm: "「#{@menu.name}」を削除しますか？"}

--- a/src/app/views/shops/show.html.slim
+++ b/src/app/views/shops/show.html.slim
@@ -4,7 +4,10 @@ ul.shop_profile
   li= "店舗名： #{@shop.name} "
   li= "営業時間：#{@shop.business_hour}"
   li= "店舗住所：#{@shop.address}"
-- if admin?
+  li
+    | 店舗オーナー：
+    = link_to @user.name, user_path(@user)
+- if admin? || @shop.user_id == current_user.id
   ul.btn-box
     li = link_to  "編集", edit_shop_path(@shop)
     li = link_to  "削除", shop_path, method: "delete", data: {confirm: "「#{@shop.name}」を削除しますか？"}
@@ -17,7 +20,7 @@ ul.shop_profile
     ul.menu-profile
       / li= "メニューID：#{menu.id}"
       li
-        - if admin?
+        - if admin? || menu.shop.user_id == current_user.id
           = link_to  "編集 ", edit_menu_path(menu.id)
           = link_to  "削除 ", menu_path(menu.id), method: "delete", data: {confirm: "「#{menu.name}」を削除しますか？"}
         | ❤︎ #{menu.likes.count} 

--- a/src/app/views/users/show.html.slim
+++ b/src/app/views/users/show.html.slim
@@ -1,12 +1,19 @@
 - provide :title, "#{@user.name}"
 ul
+  -if @user.admin?
+    li= "管理者権限：あり"
   li= "名前：#{@user.name}"
   li= "性別：#{@user.sex}" 
   - birthday = @user.birthday
   li= "生年月日：#{birthday.strftime("%Y年%m月%d日") }"
   li= "メールアドレス：#{@user.email}"
-  -if @user.admin?
-    li= "管理者権限：あり"
+  li
+    | 経営店舗：
+    ul.user-shops-list
+    - @user_shops.each do |shop|
+      li
+      = link_to shop.name, shop_path(shop)
+
 - if admin? || current_user?(@user)
   ul.btn-box
     li= link_to "編集", edit_user_path(@user)

--- a/src/db/migrate/20211222051438_add_column_user_id_to_shops.rb
+++ b/src/db/migrate/20211222051438_add_column_user_id_to_shops.rb
@@ -1,0 +1,5 @@
+class AddColumnUserIdToShops < ActiveRecord::Migration[6.1]
+  def change
+    add_column :shops, :user_id, :integer
+  end
+end

--- a/src/db/schema.rb
+++ b/src/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_20_222649) do
+ActiveRecord::Schema.define(version: 2021_12_22_051438) do
 
   create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "menu_id"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2021_12_20_222649) do
     t.string "address"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "user_id"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/src/db/seeds/shops.rb
+++ b/src/db/seeds/shops.rb
@@ -1,72 +1,91 @@
+user_id = 1
 name = 'スターバックスコーヒー小平天神店'
 business_hour = '07:00～22:30'
 address = '187-0004 東京都小平市天神町1-12-9'
 Shop.create!(name: name,
              business_hour: business_hour,
-             address: address)
-name = 'ドトールコーヒーショップ 所沢店'
-business_hour = '07:00～21:00'
-address = '359-1123 埼玉県所沢市日吉町３−５ 第３Ｅ－Ｆビル'
-Shop.create!(name: name,
-             business_hour: business_hour,
-             address: address)
+             address: address,
+             user_id: user_id)
 name = 'タリーズコーヒーショップ 所沢店'
 business_hour = '07:00～21:00'
 address = '359-1123 埼玉県所沢市日吉町３−５ 第３Ｅ－Ｆビル'
 Shop.create!(name: name,
              business_hour: business_hour,
-             address: address)
+             address: address,
+             user_id: user_id)
 name = 'FREEMAN COFFEE'
 business_hour = '07:00～21:00'
 address = '渋谷のどこか'
 Shop.create!(name: name,
              business_hour: business_hour,
-             address: address)
+             address: address,
+             user_id: user_id)
+
+user_id = 2
+name = 'ドトールコーヒーショップ 所沢店'
+business_hour = '07:00～21:00'
+address = '359-1123 埼玉県所沢市日吉町３−５ 第３Ｅ－Ｆビル'
+Shop.create!(name: name,
+             business_hour: business_hour,
+             address: address,
+             user_id: user_id)
 name = 'cafice'
 business_hour = '07:00～21:00'
 address = '新宿のどこか'
 Shop.create!(name: name,
              business_hour: business_hour,
-             address: address)
+             address: address,
+             user_id: user_id)
 name = 'ドトールコーヒー 田無駅前店'
 business_hour = '07:00～21:00'
 address = '田無のどこか'
 Shop.create!(name: name,
              business_hour: business_hour,
-             address: address)
+             address: address,
+             user_id: user_id)
+
+user_id = 3
 name = '星野コーヒー 新宿西口店'
 business_hour = '07:00～21:00'
 address = '新宿のどこか'
 Shop.create!(name: name,
              business_hour: business_hour,
-             address: address)
+             address: address,
+             user_id: user_id)
 name = 'スターバックスコーヒー サンリブシティ小倉店'
 business_hour = '07:00～21:00'
 address = '北九州のどこか'
 Shop.create!(name: name,
              business_hour: business_hour,
-             address: address)
+             address: address,
+             user_id: user_id)
 name = 'ドトールコーヒーショップ 花小金井店'
 business_hour = '07:00～21:00'
 address = '花小金井のどこか'
 Shop.create!(name: name,
              business_hour: business_hour,
-             address: address)
+             address: address,
+             user_id: user_id)
+
+user_id = 4
 name = 'スターバックスコーヒー 渋谷スクランブルスクエア店'
 business_hour = '07:00～21:00'
 address = '渋谷のどこか'
 Shop.create!(name: name,
              business_hour: business_hour,
-             address: address)
+             address: address,
+             user_id: user_id)
 name = 'シェアラウンジ 渋谷スクランブルスクエア店'
 business_hour = '07:00～21:00'
 address = '渋谷のどこか'
 Shop.create!(name: name,
              business_hour: business_hour,
-             address: address)
+             address: address,
+             user_id: user_id)
 name = 'スターバックスコーヒー 国分寺駅店'
 business_hour = '07:00～21:00'
 address = '国分寺のどこか'
 Shop.create!(name: name,
              business_hour: business_hour,
-             address: address)
+             address: address,
+             user_id: user_id)


### PR DESCRIPTION
close #46 

店舗オーナーの概念を追加し、foodbook全体を最適化。
・ログイン中にのみ店舗登録が可能に。店舗登録時、カレントユーザーが店舗オーナーとして登録される。
・店舗情報と店舗のメニューの新規登録、編集、削除はfoodbook管理者と店舗オーナーのみ可能
・メニュー登録時はカレントユーザーが経営している店舗一覧からをプルダウンで選んで、選択店舗のメニューが新規登録できる。